### PR TITLE
Update the `net_certificate` table to return an error for any non-ok response status code. Closes #36

### DIFF
--- a/net/table_net_certificate.go
+++ b/net/table_net_certificate.go
@@ -318,13 +318,13 @@ func getRevocationInformation(ctx context.Context, d *plugin.QueryData, h *plugi
 	// Check Certificate Revocation List (CRL) to verify certificate revocation status
 	isRevokedByCAOrOwner, err := isCertificateRevokedByCA(ctx, data.CRLDistributionPoints, data.SerialNumber)
 	if err != nil {
-		plugin.Logger(ctx).Error("net_certificate.getCertificateTransparencyLogs", "error getting revocation information from CRL", err)
+		plugin.Logger(ctx).Error("net_certificate.getRevocationInformation", "error getting revocation information from CRL", err)
 	}
 
 	// Check Online Certificate Status Protocol (OCSP) to verify certificate revocation status
 	ocspCertificateRevocationInfo, err := fetchOCSPDetails(ctx, data)
 	if err != nil {
-		plugin.Logger(ctx).Error("net_certificate.getCertificateTransparencyLogs", "error getting revocation information from OCSP server", err)
+		plugin.Logger(ctx).Error("net_certificate.getRevocationInformation", "error getting revocation information from OCSP server", err)
 	}
 
 	if ocspCertificateRevocationInfo != nil {
@@ -332,7 +332,7 @@ func getRevocationInformation(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 
 	if isRevokedByCAOrOwner == nil && ocspCertificateRevocationInfo == nil {
-		return nil, errors.New("unable to retrieve certificate revocation information")
+		return nil, errors.New("failed to retrieve certificate revocation information")
 	}
 
 	isRevoked := false

--- a/net/table_net_certificate.go
+++ b/net/table_net_certificate.go
@@ -280,8 +280,10 @@ func getCertificateTransparencyLogs(ctx context.Context, d *plugin.QueryData, h 
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve certificate transparency log: %v", err)
 	}
-	if resp.StatusCode == 502 {
-		return nil, fmt.Errorf("failed to complete the request for %s: %v. Please try again.", domainName, resp.Status)
+
+	statusOK := resp.StatusCode >= 200 && resp.StatusCode < 300
+	if !statusOK {
+		return nil, fmt.Errorf("failed to complete the request for %s: %v.", domainName, resp.Status)
 	}
 	defer resp.Body.Close()
 

--- a/net/table_net_certificate.go
+++ b/net/table_net_certificate.go
@@ -280,6 +280,9 @@ func getCertificateTransparencyLogs(ctx context.Context, d *plugin.QueryData, h 
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve certificate transparency log: %v", err)
 	}
+	if resp.StatusCode == 502 {
+		return nil, fmt.Errorf("failed to complete the request for %s: %v. Please try again.", domainName, resp.Status)
+	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)

--- a/net/table_net_tls_connection.go
+++ b/net/table_net_tls_connection.go
@@ -146,7 +146,7 @@ func getTLSConnection(ctx context.Context, address string, protocol string, ciph
 
 	conn, err := tls.DialWithDialer(&net.Dialer{}, "tcp", address, &cfg)
 	if err != nil {
-		plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "TLS connection failed: ", err)
+		plugin.Logger(ctx).Error("net_tls_connection.getTLSConnection", "TLS connection failed: ", err)
 		return nil, errors.New(err.Error())
 	}
 
@@ -172,7 +172,7 @@ func checkFallbackSCSVSupport(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	conn, err := tls.DialWithDialer(&net.Dialer{}, "tcp", addr, &cfg)
 	if err != nil {
-		plugin.Logger(ctx).Error("net_certificate.checkFallbackSCSVSupport", "check_fallback_scsv_support", err)
+		plugin.Logger(ctx).Error("net_tls_connection.checkFallbackSCSVSupport", "check_fallback_scsv_support", err)
 		return false, nil
 	}
 
@@ -202,7 +202,7 @@ func checkAPLNSupport(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	conn, err := tls.DialWithDialer(&net.Dialer{}, "tcp", addr, &cfg)
 	if err != nil {
-		plugin.Logger(ctx).Error("net_certificate.checkAPLNSupport", "check_tls_alpn_support", err)
+		plugin.Logger(ctx).Error("net_tls_connection.checkAPLNSupport", "check_tls_alpn_support", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
