### PR TITLE
Fix `net_certificate` table to return zero rows if domains does not have a certificate. Closes #41

### DIFF
--- a/net/table_net_certificate.go
+++ b/net/table_net_certificate.go
@@ -154,10 +154,6 @@ func tableNetCertificateList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &cfg)
-	if conn != nil {
-		defer conn.Close()
-	}
-
 	if err != nil {
 		if tcpConnectionCreated {
 			plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "failed to perform TLS handshake:", err)
@@ -166,6 +162,7 @@ func tableNetCertificateList(ctx context.Context, d *plugin.QueryData, h *plugin
 		plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "TLS connection failed:", err)
 		return nil, errors.New("TLS connection failed: " + err.Error())
 	}
+	defer conn.Close()
 
 	items := conn.ConnectionState().PeerCertificates
 

--- a/net/table_net_certificate.go
+++ b/net/table_net_certificate.go
@@ -154,15 +154,18 @@ func tableNetCertificateList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &cfg)
+	if conn != nil {
+		defer conn.Close()
+	}
+
 	if err != nil {
 		if tcpConnectionCreated {
-			plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "failed to perform TLS handshake: ", err)
+			plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "failed to perform TLS handshake:", err)
 			return nil, nil
 		}
-		plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "TLS connection failed: ", err)
+		plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "TLS connection failed:", err)
 		return nil, errors.New("TLS connection failed: " + err.Error())
 	}
-	defer conn.Close()
 
 	items := conn.ConnectionState().PeerCertificates
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
