### PR TITLE
Add check to not entirely abort when invalid DNS entry is found

### DIFF
--- a/net/table_net_certificate.go
+++ b/net/table_net_certificate.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"syscall"
 	"time"
 
@@ -159,7 +160,11 @@ func tableNetCertificateList(ctx context.Context, d *plugin.QueryData, h *plugin
 			plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "failed to perform TLS handshake:", err)
 			return nil, nil
 		}
+		if strings.HasSuffix(err.Error(), ": no such host") {
+			return nil, nil
+		}
 		plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "TLS connection failed:", err)
+
 		return nil, errors.New("TLS connection failed: " + err.Error())
 	}
 	defer conn.Close()

--- a/net/table_net_certificate.go
+++ b/net/table_net_certificate.go
@@ -160,14 +160,14 @@ func tableNetCertificateList(ctx context.Context, d *plugin.QueryData, h *plugin
 			return nil, nil
 		}
 		// Return nil, if the given host couldn't be found
-        	if opErr, ok := err.(*net.OpError); ok {
-		        if dnsError, isDnsError := opErr.Err.(*net.DNSError); isDnsError {
-			        if dnsError.IsNotFound {
-				        plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "failed to find the host:", err)
-				        return nil, nil
-			        }
-		        }
-        	}
+		if opErr, ok := err.(*net.OpError); ok {
+			if dnsError, isDnsError := opErr.Err.(*net.DNSError); isDnsError {
+				if dnsError.IsNotFound {
+					plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "failed to find the host:", err)
+					return nil, nil
+				}
+			}
+		}
 		plugin.Logger(ctx).Error("net_certificate.tableNetCertificateList", "TLS connection failed:", err)
 
 		return nil, errors.New("TLS connection failed: " + err.Error())


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

> echo "select domain, not_after from net_certificate where domain IN ('www.tamu.edu', 'blahblah.blah');" | steampipe query
+--------------+---------------------------+
| domain       | not_after                 |
+--------------+---------------------------+
| www.tamu.edu | 2023-01-19T17:59:59-06:00 |
+--------------+---------------------------+
</details>
