### PR TITLE
Fix net_certificate example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ For example:
 ```sql
 select
   issuer, 
-  not_before as exp_date 
+  not_after as exp_date 
 from 
   net_certificate
 where


### PR DESCRIPTION
Using `not_before` as expiration is incorrect, `not_after` is what is needed.