### PR TITLE
Increase buffer size to 4096 for net_dns_record requests

### DIFF
--- a/net/table_net_dns_record.go
+++ b/net/table_net_dns_record.go
@@ -248,6 +248,8 @@ func tableDNSRecordList(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 			m := new(dns.Msg)
 			m.SetQuestion(dns.Fqdn(domain), dnsTypeEnumVal)
 			m.RecursionDesired = true
+			// Increase buffer size for truncated responses
+			m.SetEdns0(4096, false)
 
 			co, err := c.Dial(dnsServer)
 			if err != nil {


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
select value from net_dns_record where domain = 'github.com' and type = 'TXT'
```
</details>
